### PR TITLE
[P2] [TERRAFORM] Cloudwatch

### DIFF
--- a/terraform/P2/main.tf
+++ b/terraform/P2/main.tf
@@ -67,6 +67,13 @@ module "database" {
   })
 }
 
+module "cloudwatch_cpu_alarm" {
+  source = "./modules/cloudwatch"
+  min_cpu_percent_alarm = 5
+  max_cpu_percent_alarm = 80
+  asg_name = module.alb_asg.asg_name
+}
+
 resource "null_resource" "print_alb_dns_name" {
   triggers = {
     always_run = "${timestamp()}"

--- a/terraform/P2/main.tf
+++ b/terraform/P2/main.tf
@@ -22,8 +22,8 @@ module "vpc" {
 }
 
 locals {
-  db_port     = 27017
-  git_branch  = "main"
+  db_port    = 27017
+  git_branch = "main"
 }
 
 module "alb_asg" {
@@ -46,7 +46,7 @@ module "alb_asg" {
   vpc_id                     = module.vpc.vpc_id
   user_data = templatefile("./scripts/webapp_user_data.sh", {
     alb_dns_name = module.alb_asg.alb_dns_name
-    db_host_ip      = module.database.db_instance_ip
+    db_host_ip   = module.database.db_instance_ip
     db_port      = local.db_port
     git_branch   = local.git_branch
   })
@@ -62,16 +62,16 @@ module "database" {
   private_subnet_ids = module.vpc.private_subnet_ids
   webapp_sg_id       = module.alb_asg.webapp_sg_id
   user_data = templatefile("./scripts/database_user_data.sh", {
-    db_port     = local.db_port
-    git_branch  = local.git_branch
+    db_port    = local.db_port
+    git_branch = local.git_branch
   })
 }
 
 module "cloudwatch_cpu_alarm" {
-  source = "./modules/cloudwatch"
-  min_cpu_percent_alarm = 5
-  max_cpu_percent_alarm = 80
-  asg_name = module.alb_asg.asg_name
+  source                = "./modules/cloudwatch"
+  min_cpu_percent_alarm = 5 #5
+  max_cpu_percent_alarm = 80 #80
+  asg_name              = module.alb_asg.asg_name
 }
 
 resource "null_resource" "print_alb_dns_name" {

--- a/terraform/P2/modules/alb_asg/outputs.tf
+++ b/terraform/P2/modules/alb_asg/outputs.tf
@@ -5,3 +5,7 @@ output "alb_dns_name" {
 output "webapp_sg_id" {
   value = [aws_security_group.sg-WebApp-instances.id]
 }
+
+output "asg_name" {
+  value = aws_autoscaling_group.webapp-autoscaling.name
+}

--- a/terraform/P2/modules/cloudwatch/main.tf
+++ b/terraform/P2/modules/cloudwatch/main.tf
@@ -4,7 +4,7 @@ resource "aws_autoscaling_policy" "cpu-policy-scaleup" {
     autoscaling_group_name = var.asg_name
     adjustment_type = "ChangeInCapacity"
     scaling_adjustment = 1 #Nb of members by which to scale
-    cooldown = 300 #Amount of time, in seconds, after a scaling activity completes and before the next scaling activity can start.
+    cooldown = 120 #Amount of time, in seconds, after a scaling activity completes and before the next scaling activity can start.
     policy_type = "SimpleScaling"
 }
 
@@ -16,7 +16,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu-alarm-scaleup" {
   evaluation_periods = 2 
   metric_name = "CPUUtilization"
   namespace = "AWS/EC2"
-  period = 120 #seconds
+  period = 10 #seconds
   statistic = "Average"
   threshold = var.max_cpu_percent_alarm
 
@@ -35,7 +35,7 @@ resource "aws_autoscaling_policy" "cpu-policy-scaledown" {
   autoscaling_group_name = var.asg_name
   adjustment_type = "ChangeInCapacity"
   scaling_adjustment = "-1"
-  cooldown = 300
+  cooldown = 120
   policy_type = "SimpleScaling"
 }
 
@@ -46,7 +46,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu-alarm-scaledown" {
   evaluation_periods = 2
   metric_name = "CPUUtilization"
   namespace = "AWS/EC2"
-  period = 120
+  period = 10
   statistic = "Average"
   threshold = var.min_cpu_percent_alarm
 

--- a/terraform/P2/modules/cloudwatch/main.tf
+++ b/terraform/P2/modules/cloudwatch/main.tf
@@ -9,7 +9,7 @@ resource "aws_autoscaling_policy" "cpu-policy-scaleup" {
 }
 
 # CPU metrics to scale up
-resource "aws_cloudwatch_metric_alarm" "cpu-alarm" {
+resource "aws_cloudwatch_metric_alarm" "cpu-alarm-scaleup" {
   alarm_name = "cpu-alarm"
   alarm_description = "cpu-alarm"
   comparison_operator = "GreaterThanOrEqualToThreshold"

--- a/terraform/P2/modules/cloudwatch/main.tf
+++ b/terraform/P2/modules/cloudwatch/main.tf
@@ -1,0 +1,61 @@
+# Scale Up alarm
+resource "aws_autoscaling_policy" "cpu-policy-scaleup" {
+    name = "cpu-policy-scaleup"
+    autoscaling_group_name = var.asg_name
+    adjustment_type = "ChangeInCapacity"
+    scaling_adjustment = 1 #Nb of members by which to scale
+    cooldown = 300 #Amount of time, in seconds, after a scaling activity completes and before the next scaling activity can start.
+    policy_type = "SimpleScaling"
+}
+
+# CPU metrics to scale up
+resource "aws_cloudwatch_metric_alarm" "cpu-alarm" {
+  alarm_name = "cpu-alarm"
+  alarm_description = "cpu-alarm"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods = 2 
+  metric_name = "CPUUtilization"
+  namespace = "AWS/EC2"
+  period = 120 #seconds
+  statistic = "Average"
+  threshold = var.max_cpu_percent_alarm
+
+  #Add here ressources you want to monitor with the cloudwatch
+  dimensions = {
+    "AutoScalingGroupName" = var.asg_name
+  }
+
+  actions_enabled = true
+  alarm_actions = [ aws_autoscaling_policy.cpu-policy-scaleup.arn ]
+}
+
+# Scale down alarm
+resource "aws_autoscaling_policy" "cpu-policy-scaledown" {
+  name = "cpu-policy-scaledown"
+  autoscaling_group_name = var.asg_name
+  adjustment_type = "ChangeInCapacity"
+  scaling_adjustment = "-1"
+  cooldown = 300
+  policy_type = "SimpleScaling"
+}
+
+resource "aws_cloudwatch_metric_alarm" "cpu-alarm-scaledown" {
+  alarm_name = "cpu-alarm-scaledown"
+  alarm_description = "cpu-alarm-scaledown"
+  comparison_operator = "LessThanOrEqualToThreshold"
+  evaluation_periods = 2
+  metric_name = "CPUUtilization"
+  namespace = "AWS/EC2"
+  period = 120
+  statistic = "Average"
+  threshold = var.min_cpu_percent_alarm
+
+  dimensions = {
+    "AutoScalingGroupName" = var.asg_name 
+  }
+
+  actions_enabled = true
+  alarm_actions = [ aws_autoscaling_policy.cpu-policy-scaledown.arn ]
+}
+
+

--- a/terraform/P2/modules/cloudwatch/variables.tf
+++ b/terraform/P2/modules/cloudwatch/variables.tf
@@ -1,0 +1,13 @@
+variable "asg_name" {
+	description = "ASG name used to increase or decrease ec2 instances"
+}
+
+variable "max_cpu_percent_alarm" {
+  description = "% of CPU usage before scale up"
+  default = 80
+}
+
+variable "min_cpu_percent_alarm" {
+  description = "% of CPU usage before scale down"
+  default = 5
+}


### PR DESCRIPTION
![image](https://github.com/Hat-Trick-Consulting-Group/genarchi/assets/35534261/c2532e6b-37af-4af1-98f3-5d62cabf6208)


On dispose désormais d'une alarme cloudwatch pour la P2.
Cette alarme monitor l'utilisation des CPUs des VMs de notre application et se trigger quand un seuil d'utilisation est dépassé.

Pour le scale up, l'alarme se trigger quand l'utilisation des CPU dépasse les 80%. Dans cette situation, le cloudwatch va notifier l'asg pour que ce dernier génère une nouvelle VM (+1).

Pour le scale down, si l'utilisation du CPU est inférieure à 5%, le cloudwatch va notifier l'asg pour que ce dernier supprime 1 instance (-1).

REMINDER:
Le nombre d'instance max et min est cappé par l'asg.

Dans la photo ci-dessus, je vous ai montré un test de scale up avec utilisation du cpu supérieure à 0.50 %
Vous constaterez qu'une nouvelle instance de notre webapp a été créée (3 instance au lieu de 2). L'alarme a donc été trigger correctement (scale up).
